### PR TITLE
Implement simple service creation backend

### DIFF
--- a/backend/prisma/migrations/20250626162432_simple_service/migration.sql
+++ b/backend/prisma/migrations/20250626162432_simple_service/migration.sql
@@ -1,0 +1,27 @@
+-- CreateEnum
+CREATE TYPE "ServiceStatus" AS ENUM ('ACTIVE', 'INACTIVE', 'TESTING');
+
+-- CreateTable
+CREATE TABLE "SimpleService" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "category" TEXT NOT NULL,
+    "status" "ServiceStatus" NOT NULL DEFAULT 'INACTIVE',
+    "agentId" TEXT NOT NULL,
+    "model" TEXT NOT NULL,
+    "prompt" TEXT NOT NULL,
+    "inputs" JSONB NOT NULL,
+    "outputs" JSONB NOT NULL,
+    "userId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "SimpleService_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "SimpleService" ADD CONSTRAINT "SimpleService_agentId_fkey" FOREIGN KEY ("agentId") REFERENCES "Agent"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "SimpleService" ADD CONSTRAINT "SimpleService_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -198,3 +198,28 @@ model Agent {
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
 }
+
+enum ServiceStatus {
+  ACTIVE
+  INACTIVE
+  TESTING
+}
+
+model SimpleService {
+  id          String        @id @default(cuid())
+  name        String
+  description String
+  category    String
+  status      ServiceStatus @default(INACTIVE)
+  agentId     String
+  model       String
+  prompt      String
+  inputs      Json
+  outputs     Json
+  userId      String
+  createdAt   DateTime      @default(now())
+  updatedAt   DateTime      @updatedAt
+
+  agent Agent @relation(fields: [agentId], references: [id])
+  user  User  @relation(fields: [userId], references: [id])
+}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -5,9 +5,10 @@ import { PrismaModule } from './prisma/prisma.module';
 import { AuthModule } from './auth/auth.module';
 import { UserModule } from './user/user.module';
 import { AgentiaModule } from './agentia/agentia.module';
+import { ServicesModule } from './services/services.module';
 
 @Module({
-  imports: [PrismaModule, AuthModule, UserModule, AgentiaModule],
+  imports: [PrismaModule, AuthModule, UserModule, AgentiaModule, ServicesModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/backend/src/services/dto/create-service.dto.ts
+++ b/backend/src/services/dto/create-service.dto.ts
@@ -1,0 +1,33 @@
+import { IsString, IsArray } from 'class-validator';
+
+export enum ServiceStatus {
+  ACTIVE = 'ACTIVE',
+  INACTIVE = 'INACTIVE',
+  TESTING = 'TESTING',
+}
+
+export class CreateServiceDto {
+  @IsString()
+  name: string;
+
+  @IsString()
+  description: string;
+
+  @IsString()
+  category: string;
+
+  @IsString()
+  agentId: string;
+
+  @IsString()
+  model: string;
+
+  @IsString()
+  prompt: string;
+
+  @IsArray()
+  inputs: any[];
+
+  @IsArray()
+  outputs: any[];
+}

--- a/backend/src/services/dto/update-service-status.dto.ts
+++ b/backend/src/services/dto/update-service-status.dto.ts
@@ -1,0 +1,7 @@
+import { IsEnum } from 'class-validator';
+import { ServiceStatus } from './create-service.dto';
+
+export class UpdateServiceStatusDto {
+  @IsEnum(ServiceStatus)
+  status: ServiceStatus;
+}

--- a/backend/src/services/services.controller.ts
+++ b/backend/src/services/services.controller.ts
@@ -1,0 +1,44 @@
+import { Body, Controller, Get, Param, Patch, Post, Req, UseGuards } from '@nestjs/common';
+import { Request } from 'express';
+import { AuthGuard } from 'src/auth/auth.guard';
+import { ServicesService } from './services.service';
+import { CreateServiceDto, ServiceStatus } from './dto/create-service.dto';
+import { UpdateServiceStatusDto } from './dto/update-service-status.dto';
+
+interface AuthRequest extends Request {
+  user: { id: string };
+}
+
+@UseGuards(AuthGuard)
+@Controller('services')
+export class ServicesController {
+  constructor(private readonly servicesService: ServicesService) {}
+
+  @Get()
+  async getAll(@Req() req: AuthRequest) {
+    return this.servicesService.getAll(req.user.id);
+  }
+
+  @Post()
+  async create(@Req() req: AuthRequest, @Body() dto: CreateServiceDto) {
+    return this.servicesService.createService({ ...dto, userId: req.user.id });
+  }
+
+  @Patch(':id/status')
+  async updateStatus(
+    @Param('id') id: string,
+    @Body() dto: UpdateServiceStatusDto,
+    @Req() req: AuthRequest,
+  ) {
+    return this.servicesService.updateStatus(id, dto.status, req.user.id);
+  }
+
+  @Post(':id/execute')
+  async execute(
+    @Param('id') id: string,
+    @Body() body: any,
+    @Req() req: AuthRequest,
+  ) {
+    return this.servicesService.execute(id, body, req.user.id);
+  }
+}

--- a/backend/src/services/services.module.ts
+++ b/backend/src/services/services.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { ServicesService } from './services.service';
+import { ServicesController } from './services.controller';
+import { PrismaService } from 'src/prisma/prisma.service';
+import { AuthModule } from 'src/auth/auth.module';
+
+@Module({
+  imports: [AuthModule],
+  controllers: [ServicesController],
+  providers: [ServicesService, PrismaService],
+})
+export class ServicesModule {}

--- a/backend/src/services/services.service.ts
+++ b/backend/src/services/services.service.ts
@@ -1,0 +1,72 @@
+import { Injectable, NotFoundException, ForbiddenException } from '@nestjs/common';
+import axios from 'axios';
+import { PrismaService } from 'src/prisma/prisma.service';
+import { ServiceStatus } from './dto/create-service.dto';
+
+@Injectable()
+export class ServicesService {
+  constructor(private prisma: PrismaService) {}
+
+  async createService(data: {
+    name: string;
+    description: string;
+    category: string;
+    agentId: string;
+    model: string;
+    prompt: string;
+    inputs: any[];
+    outputs: any[];
+    userId: string;
+  }) {
+    return this.prisma.simpleService.create({
+      data: {
+        name: data.name,
+        description: data.description,
+        category: data.category,
+        agentId: data.agentId,
+        model: data.model,
+        prompt: data.prompt,
+        inputs: data.inputs,
+        outputs: data.outputs,
+        userId: data.userId,
+        status: ServiceStatus.TESTING,
+      },
+    });
+  }
+
+  async getAll(userId: string) {
+    return this.prisma.simpleService.findMany({ where: { userId } });
+  }
+
+  async updateStatus(id: string, status: ServiceStatus, userId: string) {
+    const service = await this.prisma.simpleService.findUnique({ where: { id } });
+    if (!service) throw new NotFoundException('Service introuvable');
+    if (service.userId !== userId) throw new ForbiddenException();
+    return this.prisma.simpleService.update({ where: { id }, data: { status } });
+  }
+
+  async execute(id: string, input: any, userId: string) {
+    const service = await this.prisma.simpleService.findUnique({
+      where: { id },
+      include: { agent: true },
+    });
+    if (!service) throw new NotFoundException('Service introuvable');
+    if (service.userId !== userId) throw new ForbiddenException();
+
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    if (service.agent.apiKey) {
+      headers['Authorization'] = `Bearer ${service.agent.apiKey}`;
+    }
+    const url = `${service.agent.apiUrl}/v1/chat/completions`;
+    const messages = [
+      { role: 'system', content: service.prompt },
+      { role: 'user', content: JSON.stringify(input) },
+    ];
+    const response = await axios.post(
+      url,
+      { model: service.model, messages },
+      { headers }
+    );
+    return response.data;
+  }
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -56,7 +56,7 @@ export const signUp = async ({
     password,
     role,
   });
-
+};
 // ——— SERVICES ————————————————————————
 
 export const fetchServices = async (): Promise<Service[]> =>


### PR DESCRIPTION
## Summary
- support LM Studio services with new `SimpleService` model
- add CRUD API for services and ability to execute an AI service
- wire Services module into the NestJS app
- fix missing closing brace in `frontend/src/lib/api.ts`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: missing ESLint dependencies)*
- `npx tsc -p backend/tsconfig.json` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685d73aab34c8321a2b9254a2c37a4c8